### PR TITLE
Add setting to allow disabling of auto-inclusion of Jandex index in JAR

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,4 +1,3 @@
-
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge
@@ -15,22 +14,22 @@ appearance, race, religion, or sexual identity and orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+*   Using welcoming and inclusive language
+*   Being respectful of differing viewpoints and experiences
+*   Gracefully accepting constructive criticism
+*   Focusing on what is best for the community
+*   Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+*   The use of sexualized language or imagery and unwelcome sexual attention or
+    advances
+*   Trolling, insulting/derogatory comments, and personal or political attacks
+*   Public or private harassment
+*   Publishing others' private information, such as a physical or electronic
+    address, without explicit permission
+*   Other conduct which could reasonably be considered inappropriate in a
+    professional setting
 
 ## Our Responsibilities
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,10 +6,10 @@ Welcome and thanks for taking the time to contribute to this project!
 
 Before submitting a PR please ensure that you have run the following sbt tasks:
 
-* `test`
-* `scripted`
-* `scalafmt`
-* `headerCheck`
+*   `test`
+*   `scripted`
+*   `scalafmt`
+*   `headerCheck`
 
 This should ensure that everything works and meets the styleguide.
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 [![Build Status](https://img.shields.io/github/actions/workflow/status/stringbean/sbt-jandex/ci.yml?branch=main)](https://github.com/stringbean/sbt-jandex/actions/workflows/ci.yml)
 [![Codacy grade](https://img.shields.io/codacy/grade/aad472c1c869488e977a198e97253d8e?label=codacy)](https://app.codacy.com/gh/stringbean/sbt-jandex)
 [![Known Vulnerabilities](https://snyk.io/test/github/stringbean/sbt-jandex/badge.svg?targetFile=build.sbt)](https://snyk.io/test/github/stringbean/sbt-jandex?targetFile=build.sbt)
-[![sbt-jandex version](https://index.scala-lang.org/stringbean/sbt-jandex/sbt-jandex/latest.svg)](https://index.scala-lang.org/stringbean/sbt-jandex/sbt-jandex) 
+[![sbt-jandex version](https://index.scala-lang.org/stringbean/sbt-jandex/sbt-jandex/latest.svg)](https://index.scala-lang.org/stringbean/sbt-jandex/sbt-jandex)
 [![GitHub Discussions](https://img.shields.io/github/discussions/stringbean/sbt-jandex)](https://github.com/stringbean/sbt-jandex/discussions)
-
 
 An sbt plugin to generate [Jandex][jandex] indexes for projects.
 
@@ -29,15 +28,15 @@ Generates Jandex index for the main classes and stores it in `jandexOutput.value
 
 ### `jandexOutput`
 
-- **Description:** Directory to store generated Jandex index in.
-- **Accepts:** `File`
-- **Default:** `crossTarget.value / jandex`
+*   **Description:** Directory to store generated Jandex index in.
+*   **Accepts:** `File`
+*   **Default:** `crossTarget.value / jandex`
 
 ### `jandexIncludeInPackage`
 
-- **Description:** Whether to include Jandex index in the main JAR. If `true` then the index will be included under
-  `META-INF/jandex.idx.
-- **Accepts:** `Boolean`
-- **Default:** `true`
+*   **Description:** Whether to include Jandex index in the main JAR. If `true` then the index will be included under
+    \`META-INF/jandex.idx.
+*   **Accepts:** `Boolean`
+*   **Default:** `true`
 
 [jandex]: https://smallrye.io/jandex

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # sbt-jandex
 
+[![Build Status](https://img.shields.io/github/actions/workflow/status/stringbean/sbt-jandex/ci.yml?branch=main)](https://github.com/stringbean/sbt-jandex/actions/workflows/ci.yml)
+[![Codacy grade](https://img.shields.io/codacy/grade/aad472c1c869488e977a198e97253d8e?label=codacy)](https://app.codacy.com/gh/stringbean/sbt-jandex)
+[![Known Vulnerabilities](https://snyk.io/test/github/stringbean/sbt-jandex/badge.svg?targetFile=build.sbt)](https://snyk.io/test/github/stringbean/sbt-jandex?targetFile=build.sbt)
+[![sbt-jandex version](https://index.scala-lang.org/stringbean/sbt-jandex/sbt-jandex/latest.svg)](https://index.scala-lang.org/stringbean/sbt-jandex/sbt-jandex) 
+[![GitHub Discussions](https://img.shields.io/github/discussions/stringbean/sbt-jandex)](https://github.com/stringbean/sbt-jandex/discussions)
+
+
 An sbt plugin to generate [Jandex][jandex] indexes for projects.
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -19,4 +19,25 @@ addSbtPlugin("software.purpledragon" % "sbt-jandex" % "<version>")
 
 Jandex indexes will automatically be generated and added to the binary JARs.
 
+## Tasks
+
+### `jandex`
+
+Generates Jandex index for the main classes and stores it in `jandexOutput.value / jandex.idx`.
+
+## Settings
+
+### `jandexOutput`
+
+- **Description:** Directory to store generated Jandex index in.
+- **Accepts:** `File`
+- **Default:** `crossTarget.value / jandex`
+
+### `jandexIncludeInPackage`
+
+- **Description:** Whether to include Jandex index in the main JAR. If `true` then the index will be included under
+  `META-INF/jandex.idx.
+- **Accepts:** `Boolean`
+- **Default:** `true`
+
 [jandex]: https://smallrye.io/jandex

--- a/src/sbt-test/jandex/no-include/build.sbt
+++ b/src/sbt-test/jandex/no-include/build.sbt
@@ -3,9 +3,11 @@ scalaVersion := "2.13.10"
 
 libraryDependencies += "jakarta.enterprise" % "jakarta.enterprise.cdi-api" % "4.0.1" % Provided
 
-val verifyJarIndex = taskKey[Unit]("check Jandex index is in JAR")
+jandexIncludeInPackage := false
 
-verifyJarIndex := {
+val verifyJarNoIndex = taskKey[Unit]("check Jandex index is not in JAR")
+
+verifyJarNoIndex := {
   import scala.util.Using
   import java.util.jar.JarFile
 
@@ -14,7 +16,7 @@ verifyJarIndex := {
   val jarFile = new JarFile(projectJar)
   val indexEntry = jarFile.getEntry("META-INF/jandex.idx")
 
-  if (indexEntry == null) {
-    sys.error("Missing jandex.idx in JAR")
+  if (indexEntry != null) {
+    sys.error("jandex.idx found in JAR")
   }
 }

--- a/src/sbt-test/jandex/no-include/project/plugins.sbt
+++ b/src/sbt-test/jandex/no-include/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("software.purpledragon" % "sbt-jandex" % pluginVersion)
+}

--- a/src/sbt-test/jandex/no-include/src/main/scala/com/example/Greeter.scala
+++ b/src/sbt-test/jandex/no-include/src/main/scala/com/example/Greeter.scala
@@ -1,0 +1,10 @@
+package com.example
+
+import jakarta.enterprise.context.ApplicationScoped
+
+@ApplicationScoped
+class Greeter {
+  def greet(name: String): String = {
+    s"Hello, $name!"
+  }
+}

--- a/src/sbt-test/jandex/no-include/test
+++ b/src/sbt-test/jandex/no-include/test
@@ -1,0 +1,6 @@
+# check index file is generated
+> jandex
+$ exists target/scala-2.13/jandex/jandex.idx
+
+# check that index file is included in JAR
+> verifyJarNoIndex


### PR DESCRIPTION
Adds a new setting (`jandexIncludeInPackage`) that if set to `false` will disable inclusion of the Jandex index in the binary JAR. Indexes can still be generated using the `jandex` task so they can be bundled via alternative mechanisms.

This should allow for more flexibility.
